### PR TITLE
Find and replace completed for consistency

### DIFF
--- a/backend/controllers/orgUsersController.js
+++ b/backend/controllers/orgUsersController.js
@@ -43,7 +43,7 @@ const createOrgUser = async (req, res) => {
 };
 
 const findOrgUserById = async (req, res) => {
-  const orgUserId = req.params;
+  const orgUserId = req.params.org_user_id;
   try {
     const orgUser = await OrgUser.find({_id:orgUserId});
     res.status(200).json(orgUser);

--- a/backend/controllers/orgUsersController.js
+++ b/backend/controllers/orgUsersController.js
@@ -43,7 +43,7 @@ const createOrgUser = async (req, res) => {
 };
 
 const findOrgUserById = async (req, res) => {
-  const orgUserId = req.params.org_user_id;
+  const orgUserId = req.params;
   try {
     const orgUser = await OrgUser.find({_id:orgUserId});
     res.status(200).json(orgUser);

--- a/backend/routes/orgUsers.js
+++ b/backend/routes/orgUsers.js
@@ -5,7 +5,7 @@ const {loginOrgUser, createOrgUser, findOrgUserById, getAllOrgUsers} = require("
 
 router.post("/login", loginOrgUser);
 router.post("/signup", createOrgUser);
-router.get("/:org_user_id", findOrgUserById);
+router.get("/:org-user-id", findOrgUserById);
 router.get("/", getAllOrgUsers)
 
 module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -22,9 +22,9 @@ app.use((req, res, next) => {
 });
 
 // routes
-app.use("/api/orgUsers", orgUserRoutes);
+app.use("/api/org-users", orgUserRoutes);
 app.use("/api/listings", listingRoutes);
-app.use('/api/indUsers', indUserRoutes);
+app.use('/api/ind-users', indUserRoutes);
 
 if (process.env.NODE_ENV !== "test") {
   mongoose

--- a/backend/spec/controllers/indUsersController.spec.js
+++ b/backend/spec/controllers/indUsersController.spec.js
@@ -12,7 +12,7 @@ describe("/indUsers", () => {
   describe("POST, when user first name, surname, email and password are valid", () => {
     test("the response code is 201 and returns a message to say signup has been successful", async () => {
       let response = await agent
-        .post("/api/indUsers")
+        .post("/api/ind-users")
         .send({ 
           firstName: "John", 
           surname: "Jason", 
@@ -29,7 +29,7 @@ describe("/indUsers", () => {
     describe("POST, when user first name, surname, email or password are invalid", () => {
     test("the response code is 400 and returns an error stating first name is required", async () => {
       let response = await agent
-        .post("/api/indUsers")
+        .post("/api/ind-users")
         .send({ 
           firstName: "", 
           surname: "Jason", 
@@ -44,7 +44,7 @@ describe("/indUsers", () => {
 
     test("the response code is 400 and returns an error stating surname is required", async () => {
       let response = await agent
-        .post("/api/indUsers")
+        .post("/api/ind-users")
         .send({ 
           firstName: "John", 
           surname: "", 
@@ -59,7 +59,7 @@ describe("/indUsers", () => {
 
     test("the response code is 400 and returns an error stating an email address is required", async () => {
       let response = await agent
-        .post("/api/indUsers")
+        .post("/api/ind-users")
         .send({ 
           firstName: "John", 
           surname: "Jason", 
@@ -74,7 +74,7 @@ describe("/indUsers", () => {
 
      test("the response code is 400 and returns an error stating a valid email address is required", async () => {
       let response = await agent
-        .post("/api/indUsers")
+        .post("/api/ind-users")
         .send({ 
           firstName: "John", 
           surname: "Jason", 
@@ -89,7 +89,7 @@ describe("/indUsers", () => {
 
     test("the response code is 400 and returns an error stating a password is required", async () => {
       let response = await agent
-        .post("/api/indUsers")
+        .post("/api/ind-users")
         .send({ 
           firstName: "John", 
           surname: "Jason", 
@@ -104,7 +104,7 @@ describe("/indUsers", () => {
 
     test("the response code is 400 and returns an error stating a valid password is required", async () => {
       let response = await agent
-        .post("/api/indUsers")
+        .post("/api/ind-users")
         .send({ 
           firstName: "John", 
           surname: "Jason", 

--- a/backend/spec/controllers/orgUsersController.spec.js
+++ b/backend/spec/controllers/orgUsersController.spec.js
@@ -19,7 +19,7 @@ describe("OrgUser Controller", () => {
         password: "ABCabc123!",
       };
 
-      const response = await agent.post(`/api/orgUsers/signup`).send(orgUser);
+      const response = await agent.post(`/api/org-users/signup`).send(orgUser);
 
       expect(response.statusCode).toBe(201);
       expect(response.body).toEqual(
@@ -39,7 +39,7 @@ describe("OrgUser Controller", () => {
         password: "ABCabc123!",
       };
 
-      const response = await agent.post(`/api/orgUsers/signup`).send(orgUser);
+      const response = await agent.post(`/api/org-users/signup`).send(orgUser);
 
       expect(response.statusCode).toBe(201);
       expect(response.body).toEqual(
@@ -58,10 +58,10 @@ describe("OrgUser Controller", () => {
       };
 
       const signupResponse = await agent
-        .post(`/api/orgUsers/signup`)
+        .post(`/api/org-users/signup`)
         .send(orgUser);
       
-      const getOrgUserResponse = await agent.get(`/api/orgUsers/${signupResponse.body._id}`);
+      const getOrgUserResponse = await agent.get(`/api/org-users/${signupResponse.body._id}`);
 
       expect(getOrgUserResponse.body).toEqual({
         organisationName: getOrgUserResponse.organisationName,
@@ -71,7 +71,7 @@ describe("OrgUser Controller", () => {
 
   describe("It display error messages when a client signups with missing or invalid inputs", () => {
     test("response code is 400 when organisationName is missing", async () => {
-      let response = await request(server).post(`/api/orgUsers/signup`).send({
+      let response = await request(server).post(`/api/org-users/signup`).send({
         organisationName: "",
         email: "puppy@gmail.com",
         charityNumber: 123456,
@@ -84,7 +84,7 @@ describe("OrgUser Controller", () => {
     });
 
     test("response code is 400 when email address is missing", async () => {
-      let response = await request(server).post(`/api/orgUsers/signup`).send({
+      let response = await request(server).post(`/api/org-users/signup`).send({
         organisationName: "Puppies Trust",
         email: "",
         charityNumber: 123456,
@@ -97,7 +97,7 @@ describe("OrgUser Controller", () => {
     });
 
     test("response code is 400 when password is missing", async () => {
-      let response = await request(server).post(`/api/orgUsers/signup`).send({
+      let response = await request(server).post(`/api/org-users/signup`).send({
         organisationName: "Puppies Trust",
         email: "puppy@gmail.com",
         charityNumber: 123456,
@@ -110,7 +110,7 @@ describe("OrgUser Controller", () => {
     });
 
     test("response code is 400 when password is weak and does not meet the minimum requirement", async () => {
-      let response = await request(server).post(`/api/orgUsers/signup`).send({
+      let response = await request(server).post(`/api/org-users/signup`).send({
         organisationName: "Puppies Trust",
         email: "puppy@gmail.com",
         charityNumber: 123456,
@@ -124,7 +124,7 @@ describe("OrgUser Controller", () => {
     });
 
     test("response code is 201 when password meets all the requirement of a password", async () => {
-      let response = await request(server).post(`/api/orgUsers/signup`).send({
+      let response = await request(server).post(`/api/org-users/signup`).send({
         organisationName: "Puppies Trust",
         email: "puppy@gmail.com",
         charityNumber: 123456,
@@ -134,7 +134,7 @@ describe("OrgUser Controller", () => {
     });
 
     test("response code is 400 when email address is not valid", async () => {
-      let response = await request(server).post(`/api/orgUsers/signup`).send({
+      let response = await request(server).post(`/api/org-users/signup`).send({
         organisationName: "Puppies Trust",
         email: "incorrectemail@",
         charityNumber: 123456,
@@ -147,7 +147,7 @@ describe("OrgUser Controller", () => {
     });
 
     test("response code is 201 when email address is valid", async () => {
-      let response = await request(server).post(`/api/orgUsers/signup`).send({
+      let response = await request(server).post(`/api/org-users/signup`).send({
         organisationName: "Puppies Trust",
         email: "puppy@gmail.com",
         charityNumber: 123456,
@@ -166,7 +166,7 @@ describe("OrgUser Controller", () => {
         password: "ABCabc123!",
       };
 
-      const orgSignsUp1 = await agent.post(`/api/orgUsers/signup`).send(orgUser1);
+      const orgSignsUp1 = await agent.post(`/api/org-users/signup`).send(orgUser1);
 
       const orgUser2 = {
         organisationName: "Puppies Trust 2",
@@ -175,7 +175,7 @@ describe("OrgUser Controller", () => {
         password: "ABCabc123!",
       };
 
-      const orgSignsUpAgain = await agent.post(`/api/orgUsers/signup`).send(orgUser2);
+      const orgSignsUpAgain = await agent.post(`/api/org-users/signup`).send(orgUser2);
       expect(orgSignsUpAgain.statusCode).toBe(400);
       expect(orgSignsUpAgain.body).toEqual({
         error: "User already exists"
@@ -192,13 +192,13 @@ describe("OrgUser Controller", () => {
     };
     
     test("displays an error message if the email address is incorrect", async() => {
-      const signupResponse = await agent.post(`/api/orgUsers/signup`).send(orgUser);
+      const signupResponse = await agent.post(`/api/org-users/signup`).send(orgUser);
       const orgUserHasAccount = {
         email: "incorrectemail@gmail.com",
         password: "ABCabc123!"
       };
 
-      const loginResponse = await agent.post(`/api/orgUsers/login`).send(orgUserHasAccount);
+      const loginResponse = await agent.post(`/api/org-users/login`).send(orgUserHasAccount);
       expect(loginResponse.statusCode).toBe(400)
       expect(loginResponse.body).toEqual({
         error: "Incorrect email"
@@ -206,13 +206,13 @@ describe("OrgUser Controller", () => {
     })
 
     test("displays an error message if the password is incorrect", async() => {
-      const signupResponse = await agent.post(`/api/orgUsers/signup`).send(orgUser);
+      const signupResponse = await agent.post(`/api/org-users/signup`).send(orgUser);
       const orgUserHasAccount = {
         email: "puppy@gmail.com",
         password: "incorrectPassword"
       };
 
-      const loginResponse = await agent.post(`/api/orgUsers/login`).send(orgUserHasAccount);
+      const loginResponse = await agent.post(`/api/org-users/login`).send(orgUserHasAccount);
 
       expect(loginResponse.statusCode).toBe(400)
       expect(loginResponse.body).toEqual({
@@ -221,13 +221,13 @@ describe("OrgUser Controller", () => {
     })
 
     test("displays an error message when email address and password have not been submitted", async() => {
-      const signupResponse = await agent.post(`/api/orgUsers/signup`).send(orgUser);
+      const signupResponse = await agent.post(`/api/org-users/signup`).send(orgUser);
       const orgUserHasAccount = {
         email: "",
         password: ""
       };
 
-      const loginResponse = await agent.post(`/api/orgUsers/login`).send(orgUserHasAccount);
+      const loginResponse = await agent.post(`/api/org-users/login`).send(orgUserHasAccount);
 
       expect(loginResponse.statusCode).toBe(400)
       expect(loginResponse.body).toEqual({
@@ -236,13 +236,13 @@ describe("OrgUser Controller", () => {
     })
 
     test("response code is 200 when email and password matches record", async() => {
-      const signupResponse = await agent.post(`/api/orgUsers/signup`).send(orgUser);
+      const signupResponse = await agent.post(`/api/org-users/signup`).send(orgUser);
       const orgUserHasAccount = {
         email: "puppy@gmail.com",
         password: "ABCabc123!"
       };
 
-      const loginResponse = await agent.post(`/api/orgUsers/login`).send(orgUserHasAccount);
+      const loginResponse = await agent.post(`/api/org-users/login`).send(orgUserHasAccount);
 
       expect(loginResponse.statusCode).toBe(200)
       expect(loginResponse.body).toEqual({

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -19,7 +19,7 @@ const App = () => {
         <Route path="/login" element={!orgUser ? <Login /> : <Navigate to="/listings" /> } />
         <Route path="/listings" element={<Listings />} />
         <Route path="/profile" element={<Profile />} />
-        <Route path="/organisations/:org_user_id" element={<OrgProfile />} />
+        <Route path="/organisations/:org-user-id" element={<OrgProfile />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/hooks/useLogin.js
+++ b/frontend/src/hooks/useLogin.js
@@ -10,7 +10,7 @@ export const useOrgLogin = () => {
         setLoading(true);
         setError(null);
 
-    const response = await fetch('./api/orgUsers/login', {
+    const response = await fetch('./api/org-users/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password })

--- a/frontend/src/hooks/useSignup.js
+++ b/frontend/src/hooks/useSignup.js
@@ -10,7 +10,7 @@ export const useSignup = () => {
     setLoading(true);
     setError(null);
 
-    const response = await fetch("./api/orgUsers/signup", {
+    const response = await fetch("./api/org-users/signup", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/frontend/src/pages/OrgProfile.js
+++ b/frontend/src/pages/OrgProfile.js
@@ -6,7 +6,7 @@ const OrgProfile = () => {
   useEffect(() => {
     const fetchOrg = async () => {
       const orgId = window.location.pathname.split('/')[2];
-      const response = await fetch('/api/orgUsers/' + orgId);
+      const response = await fetch('/api/org-users/' + orgId);
       const json = await response.json();
       setOrg(json[0]);
     }


### PR DESCRIPTION
hey all, Thuy and I had a discussion about naming conventions and we came to conclusion it should be as follows:
* Route names should be spaced with hyphens
* Class names, variables etc. should be camel case
* Field/key names from mongodb should be spaced with underscores

Wasn't too much of a pain to change, however it had to be done as we were starting to get inconsistencies.

The find and replaces I had to do were:
`/:org_user_id` ---> `/:org-user-id`
`/api/orgUsers` ---> `/api/org-users`
`/api/indUsers` ---> `/api/ind-users`

If you have any questions please ask, if not from now on lets stick to these conventions.

(If you need to make some changes make sure to grab as much of a text portion as possible to change e.g. I grabbed the `/api/` bit as well even though it wasn't changing just to make sure I didnt replace any class names etc. Also, click on the `match case` and `match whole word` buttons if needing to change stuff in your own branches just to be safe.

Thanks team enaidle <3